### PR TITLE
fix: turnoff states testing selector

### DIFF
--- a/cypress/e2e/Acapedia/SignUp.cy.js
+++ b/cypress/e2e/Acapedia/SignUp.cy.js
@@ -15,13 +15,6 @@ describe('SignUp E2E Test', () => {
     cy.get('[name=degree]').parent().click();
     cy.contains('M.D').click();
 
-    // paused
-    // cy.get('[name=stateOfPractice]').parent().click();
-    // cy.contains('Alabama').click();
-
-    // click anywhere to close the states selector
-    // cy.get('.v-application').click();
-
     cy.contains('Continue').click();
 
     // TODO: we need a test-id here as we cannot get it by text value

--- a/cypress/e2e/Acapedia/SignUp.cy.js
+++ b/cypress/e2e/Acapedia/SignUp.cy.js
@@ -15,11 +15,12 @@ describe('SignUp E2E Test', () => {
     cy.get('[name=degree]').parent().click();
     cy.contains('M.D').click();
 
-    cy.get('[name=stateOfPractice]').parent().click();
-    cy.contains('Alabama').click();
+    // paused
+    // cy.get('[name=stateOfPractice]').parent().click();
+    // cy.contains('Alabama').click();
 
     // click anywhere to close the states selector
-    cy.get('.v-application').click();
+    // cy.get('.v-application').click();
 
     cy.contains('Continue').click();
 


### PR DESCRIPTION
## Description <!-- mandatory -->
Turnoff the states selector for the E2E due to business changes 

## Stories <!-- mandatory -->
https://app.clickup.com/t/85zt7xjtq

## List of changes <!-- mandatory -->
* E2E Signup

## Impacted Areas in Application <!-- mandatory -->
* Register

## Requires dependency installation
NO