### PR TITLE
chore: delete files after test check

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,5 +1,6 @@
 const { defineConfig } = require('cypress');
 const fs = require('fs');
+const path = require('path');
 import { addCucumberPreprocessorPlugin } from '@badeball/cypress-cucumber-preprocessor';
 import createBundler from '@bahmutov/cypress-esbuild-preprocessor';
 import createEsbuildPlugin from '@badeball/cypress-cucumber-preprocessor/esbuild';
@@ -33,9 +34,22 @@ module.exports = defineConfig({
           if (fs.existsSync(filePath)) {
             fs.unlinkSync(filePath);
             return null;
-          } else {
-            throw new Error('File does not exist');
           }
+        }
+      });
+
+      on('task', {
+        deleteAllFilesInFolder(folderPath) {
+          const files = fs.readdirSync(folderPath);
+
+          files.forEach(file => {
+            const filePath = path.join(folderPath, file);
+            if (fs.existsSync(filePath)) {
+              fs.unlinkSync(filePath);
+            }
+          });
+    
+          return null; 
         }
       });
 

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,4 +1,5 @@
 const { defineConfig } = require('cypress');
+const fs = require('fs');
 import { addCucumberPreprocessorPlugin } from '@badeball/cypress-cucumber-preprocessor';
 import createBundler from '@bahmutov/cypress-esbuild-preprocessor';
 import createEsbuildPlugin from '@badeball/cypress-cucumber-preprocessor/esbuild';
@@ -26,6 +27,17 @@ module.exports = defineConfig({
           plugins: [createEsbuildPlugin(config)],
         }),
       );
+
+      on('task', {
+        deleteFile(filePath) {
+          if (fs.existsSync(filePath)) {
+            fs.unlinkSync(filePath);
+            return null;
+          } else {
+            throw new Error('File does not exist');
+          }
+        }
+      });
 
       return config;
     },

--- a/cypress/e2e/Courses/Certificates/FreePlanAwardedCourseCertificate/FreePlanAwardedCourseCertificate.js
+++ b/cypress/e2e/Courses/Certificates/FreePlanAwardedCourseCertificate/FreePlanAwardedCourseCertificate.js
@@ -1,4 +1,12 @@
-import { Given, When, Then } from '@badeball/cypress-cucumber-preprocessor';
+import { Given, When, Then, BeforeAll } from '@badeball/cypress-cucumber-preprocessor';
+
+BeforeAll(function () {
+  const folderPath = './cypress/downloads/';
+  // delete created any files before run to avoid false positives
+  cy.task('deleteAllFilesInFolder', folderPath).then(result => {
+    expect(result).to.be.null;
+  });
+});
 
 Given('a free plan user has some completed awarded premium courses', () => {
   cy.fixture('/Courses/Certificates/credentials').then((credentials) => {
@@ -73,11 +81,6 @@ Then('the certificate should be downloaded successfully', () => {
   const filePath = './cypress/downloads/user_Course_Activity_Test_2_2024.pdf';
   cy.contains('Download certificate').click();
   cy.readFile(filePath).should('exist');
-
-    // delete created files after run to avoid false positives
-    cy.task('deleteFile', filePath).then(result => {
-      expect(result).to.be.null;
-    });
 });
 
 Given('the user navigates to the premium courses page', () => {

--- a/cypress/e2e/Courses/Certificates/FreePlanAwardedCourseCertificate/FreePlanAwardedCourseCertificate.js
+++ b/cypress/e2e/Courses/Certificates/FreePlanAwardedCourseCertificate/FreePlanAwardedCourseCertificate.js
@@ -70,8 +70,14 @@ Then('the user should see the call to action "Download certificate" for awarded 
 });
 
 Then('the certificate should be downloaded successfully', () => {
+  const filePath = './cypress/downloads/user_Course_Activity_Test_2_2024.pdf';
   cy.contains('Download certificate').click();
-  cy.readFile('./cypress/downloads/user_Course_Activity_Test_2_2024.pdf').should('exist');
+  cy.readFile(filePath).should('exist');
+
+    // delete created files after run to avoid false positives
+    cy.task('deleteFile', filePath).then(result => {
+      expect(result).to.be.null;
+    });
 });
 
 Given('the user navigates to the premium courses page', () => {

--- a/cypress/e2e/Courses/Certificates/LifetimePlanAwardedCourseCertificate/LifetimePlanAwardedCourseCertificate.js
+++ b/cypress/e2e/Courses/Certificates/LifetimePlanAwardedCourseCertificate/LifetimePlanAwardedCourseCertificate.js
@@ -1,4 +1,12 @@
-import { Given, When, Then } from '@badeball/cypress-cucumber-preprocessor';
+import { Given, When, Then, BeforeAll } from '@badeball/cypress-cucumber-preprocessor';
+
+BeforeAll(function () {
+  const folderPath = './cypress/downloads/';
+  // delete created any files before run to avoid false positives
+  cy.task('deleteAllFilesInFolder', folderPath).then(result => {
+    expect(result).to.be.null;
+  });
+});
 
 Given('a lifetime plan user has some completed awarded premium courses', () => {
   cy.fixture('/Courses/Certificates/credentials').then((credentials) => {
@@ -74,9 +82,4 @@ Then('the certificate should be downloaded successfully', () => {
   const filePath = './cypress/downloads/Course_Activity_Example_2024.pdf';
 
   cy.readFile(filePath).should('exist');
-
-  // delete created files after run to avoid false positives
-  cy.task('deleteFile', filePath).then(result => {
-    expect(result).to.be.null;
-  });
 });

--- a/cypress/e2e/Courses/Certificates/LifetimePlanAwardedCourseCertificate/LifetimePlanAwardedCourseCertificate.js
+++ b/cypress/e2e/Courses/Certificates/LifetimePlanAwardedCourseCertificate/LifetimePlanAwardedCourseCertificate.js
@@ -71,5 +71,12 @@ Then('the user should see the call to action "Review course" for awarded courses
 });
 
 Then('the certificate should be downloaded successfully', () => {
-  cy.readFile('./cypress/downloads/Course_Activity_Example_2024.pdf').should('exist');
+  const filePath = './cypress/downloads/Course_Activity_Example_2024.pdf';
+
+  cy.readFile(filePath).should('exist');
+
+  // delete created files after run to avoid false positives
+  cy.task('deleteFile', filePath).then(result => {
+    expect(result).to.be.null;
+  });
 });

--- a/cypress/e2e/Courses/Certificates/StandardPlanAwardedCourseCertificate/StandardPlanAwardedCourseCertificate.js
+++ b/cypress/e2e/Courses/Certificates/StandardPlanAwardedCourseCertificate/StandardPlanAwardedCourseCertificate.js
@@ -1,4 +1,12 @@
-import { Given, When, Then } from '@badeball/cypress-cucumber-preprocessor';
+import { Given, When, Then, BeforeAll } from '@badeball/cypress-cucumber-preprocessor';
+
+BeforeAll(function () {
+  const folderPath = './cypress/downloads/';
+  // delete created any files before run to avoid false positives
+  cy.task('deleteAllFilesInFolder', folderPath).then(result => {
+    expect(result).to.be.null;
+  });
+});
 
 Given('a standard plan user has some completed awarded premium courses', () => {
   cy.fixture('/Courses/Certificates/credentials').then((credentials) => {
@@ -73,9 +81,4 @@ Then('the certificate should be downloaded successfully', () => {
   const filePath = './cypress/downloads/Testing_The_greatest_activity_of_all_the_time_2024.pdf';
 
   cy.readFile(filePath).should('exist');
-
-  // delete created files after run to avoid false positives
-  cy.task('deleteFile', filePath).then(result => {
-    expect(result).to.be.null;
-  });
 });

--- a/cypress/e2e/Courses/Certificates/StandardPlanAwardedCourseCertificate/StandardPlanAwardedCourseCertificate.js
+++ b/cypress/e2e/Courses/Certificates/StandardPlanAwardedCourseCertificate/StandardPlanAwardedCourseCertificate.js
@@ -70,5 +70,12 @@ Then('the user should see the call to action "Review course" for awarded courses
 });
 
 Then('the certificate should be downloaded successfully', () => {
-  cy.readFile('./cypress/downloads/Testing_The_greatest_activity_of_all_the_time_2024.pdf').should('exist');
+  const filePath = './cypress/downloads/Testing_The_greatest_activity_of_all_the_time_2024.pdf';
+
+  cy.readFile(filePath).should('exist');
+
+  // delete created files after run to avoid false positives
+  cy.task('deleteFile', filePath).then(result => {
+    expect(result).to.be.null;
+  });
 });

--- a/cypress/e2e/SpecialRequirements/Certificates/FreePlanAwardedSpecialRequirementCertificate/FreePlanAwardedSpecialRequirementCertificate.js
+++ b/cypress/e2e/SpecialRequirements/Certificates/FreePlanAwardedSpecialRequirementCertificate/FreePlanAwardedSpecialRequirementCertificate.js
@@ -62,8 +62,15 @@ When('the user requests to "Download certificate"', () => {
 });
 
 Then('the certificate should be downloaded successfully', () => {
+  const filePath = './cypress/downloads/Cabrera_Controlled_Substances_Alaska_2024.pdf';
+
   cy.contains('Download certificate').click();
-  cy.readFile('./cypress/downloads/Cabrera_Controlled_Substances_Alaska_2024.pdf').should('exist');
+  cy.readFile(filePath).should('exist');
+
+  // delete created files after run to avoid false positives
+  cy.task('deleteFile', filePath).then(result => {
+    expect(result).to.be.null;
+  });
 });
 
 Then('the user should see the call to action "Download certificate" for awarded special requirements', () => {

--- a/cypress/e2e/SpecialRequirements/Certificates/FreePlanAwardedSpecialRequirementCertificate/FreePlanAwardedSpecialRequirementCertificate.js
+++ b/cypress/e2e/SpecialRequirements/Certificates/FreePlanAwardedSpecialRequirementCertificate/FreePlanAwardedSpecialRequirementCertificate.js
@@ -1,4 +1,12 @@
-import { Given, When, Then } from '@badeball/cypress-cucumber-preprocessor';
+import { Given, When, Then, BeforeAll } from '@badeball/cypress-cucumber-preprocessor';
+
+BeforeAll(function () {
+  const folderPath = './cypress/downloads/';
+  // delete created any files before run to avoid false positives
+  cy.task('deleteAllFilesInFolder', folderPath).then(result => {
+    expect(result).to.be.null;
+  });
+});
 
 Given('a free plan user has some completed awarded special requirements', () => {
   cy.fixture('/SpecialRequirements/Certificates/credentials').then((credentials) => {
@@ -66,11 +74,6 @@ Then('the certificate should be downloaded successfully', () => {
 
   cy.contains('Download certificate').click();
   cy.readFile(filePath).should('exist');
-
-  // delete created files after run to avoid false positives
-  cy.task('deleteFile', filePath).then(result => {
-    expect(result).to.be.null;
-  });
 });
 
 Then('the user should see the call to action "Download certificate" for awarded special requirements', () => {

--- a/cypress/e2e/SpecialRequirements/Certificates/LifetimePlanAwardedSpecialRequirementCertificate/LifetimePlanAwardedSpecialRequirementCertificate.js
+++ b/cypress/e2e/SpecialRequirements/Certificates/LifetimePlanAwardedSpecialRequirementCertificate/LifetimePlanAwardedSpecialRequirementCertificate.js
@@ -1,4 +1,12 @@
-import { Given, When, Then } from '@badeball/cypress-cucumber-preprocessor';
+import { Given, When, Then, BeforeAll } from '@badeball/cypress-cucumber-preprocessor';
+
+BeforeAll(function () {
+  const folderPath = './cypress/downloads/';
+  // delete created any files before run to avoid false positives
+  cy.task('deleteAllFilesInFolder', folderPath).then(result => {
+    expect(result).to.be.null;
+  });
+});
 
 Given('a lifetime plan user has some completed awarded special requirements', () => {
   cy.fixture('/SpecialRequirements/Certificates/credentials').then((credentials) => {
@@ -66,11 +74,6 @@ Then('the certificate should be downloaded successfully', () => {
 
   cy.contains('Download certificate').click();
   cy.readFile(filePath).should('exist');
-
-  // delete created files after run to avoid false positives
-  cy.task('deleteFile', filePath).then(result => {
-    expect(result).to.be.null;
-  });
 });
 
 Then('the user should see a success style for awarded special requirements', () => {

--- a/cypress/e2e/SpecialRequirements/Certificates/LifetimePlanAwardedSpecialRequirementCertificate/LifetimePlanAwardedSpecialRequirementCertificate.js
+++ b/cypress/e2e/SpecialRequirements/Certificates/LifetimePlanAwardedSpecialRequirementCertificate/LifetimePlanAwardedSpecialRequirementCertificate.js
@@ -62,8 +62,15 @@ When('the user requests to "Download certificate"', () => {
 });
 
 Then('the certificate should be downloaded successfully', () => {
+  const filePath = './cypress/downloads/Lifetime_Controlled_Substances_Alaska_2024.pdf';
+
   cy.contains('Download certificate').click();
-  cy.readFile('./cypress/downloads/Cabrera_Controlled_Substances_Alaska_2024.pdf').should('exist');
+  cy.readFile(filePath).should('exist');
+
+  // delete created files after run to avoid false positives
+  cy.task('deleteFile', filePath).then(result => {
+    expect(result).to.be.null;
+  });
 });
 
 Then('the user should see a success style for awarded special requirements', () => {

--- a/cypress/e2e/SpecialRequirements/Certificates/StandardPlanAwardedSpecialRequirementCertificate/StandardPlanAwardedSpecialRequirementCertificate.js
+++ b/cypress/e2e/SpecialRequirements/Certificates/StandardPlanAwardedSpecialRequirementCertificate/StandardPlanAwardedSpecialRequirementCertificate.js
@@ -1,4 +1,12 @@
-import { Given, When, Then } from '@badeball/cypress-cucumber-preprocessor';
+import { Given, When, Then, BeforeAll } from '@badeball/cypress-cucumber-preprocessor';
+
+BeforeAll(function () {
+  const folderPath = './cypress/downloads/';
+  // delete created any files before run to avoid false positives
+  cy.task('deleteAllFilesInFolder', folderPath).then(result => {
+    expect(result).to.be.null;
+  });
+});
 
 Given('a standard plan user has some completed awarded special requirements', () => {
   cy.fixture('/SpecialRequirements/Certificates/credentials').then((credentials) => {
@@ -66,11 +74,6 @@ Then('the certificate should be downloaded successfully', () => {
 
   cy.contains('Download certificate').click();
   cy.readFile(filePath).should('exist');
-
-  // delete created files after run to avoid false positives
-  cy.task('deleteFile', filePath).then(result => {
-    expect(result).to.be.null;
-  });
 });
 
 Then('the user should see the call to action "Download certificate" for awarded special requirements', () => {

--- a/cypress/e2e/SpecialRequirements/Certificates/StandardPlanAwardedSpecialRequirementCertificate/StandardPlanAwardedSpecialRequirementCertificate.js
+++ b/cypress/e2e/SpecialRequirements/Certificates/StandardPlanAwardedSpecialRequirementCertificate/StandardPlanAwardedSpecialRequirementCertificate.js
@@ -62,8 +62,15 @@ When('the user requests to "Download certificate"', () => {
 });
 
 Then('the certificate should be downloaded successfully', () => {
+  const filePath = './cypress/downloads/SR_standard_Controlled_Substances_Alaska_2024.pdf';
+
   cy.contains('Download certificate').click();
-  cy.readFile('./cypress/downloads/Cabrera_Controlled_Substances_Alaska_2024.pdf').should('exist');
+  cy.readFile(filePath).should('exist');
+
+  // delete created files after run to avoid false positives
+  cy.task('deleteFile', filePath).then(result => {
+    expect(result).to.be.null;
+  });
 });
 
 Then('the user should see the call to action "Download certificate" for awarded special requirements', () => {


### PR DESCRIPTION
This PR add a patch to the current tests running in the CI. Essentially removes the created files during the test to make sure that we don't have false positives (making every run self-contained in its resources).